### PR TITLE
Use fieldAccess to access interior/boundary faceI

### DIFF
--- a/src/finiteVolume/include/fieldAccess.H
+++ b/src/finiteVolume/include/fieldAccess.H
@@ -45,9 +45,9 @@ namespace Foam
 
 
 template<class Type>
-inline Type fieldAccess
+inline Type& fieldAccess
 (
-    const GeometricField<Type, fvsPatchField, surfaceMesh>& f,
+    GeometricField<Type, fvsPatchField, surfaceMesh>& f,
     const label i
 )
 {

--- a/src/finiteVolume/interpolation/surfaceInterpolation/schemes/FitData/FitData.C
+++ b/src/finiteVolume/interpolation/surfaceInterpolation/schemes/FitData/FitData.C
@@ -91,13 +91,10 @@ void Foam::FitData<FitDataType, ExtendedStencil, Polynomial>::findFaceDirs
     forAll(mesh.cellCells()[own], i)
     {
         const label celli = mesh.cellCells()[own][i];
-        if (celli < mesh.nCells())
+        jdirTmp = mesh.cellCentres()[celli] - fC;
+        if (magSqr(jdirTmp ^ idir) > magSqr(jdir ^ idir))
         {
-            jdirTmp = mesh.cellCentres()[celli] - fC;
-            if (magSqr(jdirTmp ^ idir) > magSqr(jdir ^ idir))
-            {
-                jdir = jdirTmp;
-            }
+            jdir = jdirTmp;
         }
     }
     // Remove the idir from jdir and then normalise jdir

--- a/src/finiteVolume/interpolation/surfaceInterpolation/schemes/UpwindFitScheme/StencilWeights.C
+++ b/src/finiteVolume/interpolation/surfaceInterpolation/schemes/UpwindFitScheme/StencilWeights.C
@@ -1,4 +1,5 @@
 #include "StencilWeights.H"
+#include "fieldAccess.H"
 
 Foam::StencilWeights::StencilWeights(const fvMesh& mesh, const word prefix)
 :
@@ -58,12 +59,12 @@ void Foam::StencilWeights::fitted(
 )
 {
     if (faceI == debugFaceI) populateStencilWeights(fit());
-    polynomialTerms()[faceI] = fit->polynomialTerms;
+    fieldAccess(polynomialTerms(), faceI) = fit->polynomialTerms;
 }
 
 void Foam::StencilWeights::write()
 {
-    stencilWeights->write();
+    if (debugFaceI > -1) stencilWeights->write();
     polynomialTerms->write();
 }
 


### PR DESCRIPTION
Previously, we'd introduced a bug that had only manifested itself when running in parallel, which was caused by trying to index boundary faces on the surfaceScalarField, polynomialTerms